### PR TITLE
Examples are read as col vectors

### DIFF
--- a/core/src/main/java/com/basistech/ninja/Network.java
+++ b/core/src/main/java/com/basistech/ninja/Network.java
@@ -196,7 +196,7 @@ public class Network {
         return deltas;
     }
 
-    // every example in 'x' and 'y' should b a col vector
+    // every example in 'x' and 'y' should be a col vector
     public void stochasticGD(SimpleMatrix x, SimpleMatrix y, double learningRate) {
         if (x.numCols() != y.numCols()) {
             throw new IllegalArgumentException("x and y must have the same number of columns!");
@@ -209,6 +209,7 @@ public class Network {
         }
     }
 
+    // every example in 'x' and 'y' should be a col vector
     SimpleMatrix[] computeGradient(SimpleMatrix x, SimpleMatrix y) {
         int numExamples = x.numCols();
 

--- a/core/src/main/java/com/basistech/ninja/Network.java
+++ b/core/src/main/java/com/basistech/ninja/Network.java
@@ -196,9 +196,10 @@ public class Network {
         return deltas;
     }
 
+    // every example in 'x' and 'y' should b a col vector
     public void stochasticGD(SimpleMatrix x, SimpleMatrix y, double learningRate) {
-        if (x.numRows() != y.numRows()) {
-            throw new IllegalArgumentException("x and y must have the same number of rows!");
+        if (x.numCols() != y.numCols()) {
+            throw new IllegalArgumentException("x and y must have the same number of columns!");
         }
 
         // TODO: gradient checking
@@ -209,7 +210,7 @@ public class Network {
     }
 
     SimpleMatrix[] computeGradient(SimpleMatrix x, SimpleMatrix y) {
-        int numExamples = x.numRows();
+        int numExamples = x.numCols();
 
         SimpleMatrix[] bigDelta = new SimpleMatrix[getNumLayers() - 1];
         for (int l = 0; l < getNumLayers() - 1; l++) {
@@ -217,8 +218,8 @@ public class Network {
         }
 
         for (int i = 0; i < numExamples; i++) {
-            SimpleMatrix xi = x.extractVector(true, i).transpose();
-            SimpleMatrix yi = y.extractVector(true, i).transpose();
+            SimpleMatrix xi = x.extractVector(false, i);
+            SimpleMatrix yi = y.extractVector(false, i);
             ForwardVectors fv = feedForward(xi);
             SimpleMatrix[] deltas = backprop(fv, yi);
             for (int l = 0; l < bigDelta.length; l++) {

--- a/core/src/main/java/com/basistech/ninja/Train.java
+++ b/core/src/main/java/com/basistech/ninja/Train.java
@@ -58,8 +58,9 @@ public class Train {
         int inputNeurons = net.getNumNeurons(0);
         int outputNeurons = net.getNumNeurons(net.getNumLayers() - 1);
 
-        x = new SimpleMatrix(lines.size(), inputNeurons);
-        y = new SimpleMatrix(lines.size(), outputNeurons);
+        // each example is a col vector
+        x = new SimpleMatrix(inputNeurons, lines.size());
+        y = new SimpleMatrix(outputNeurons, lines.size());
 
         int lineno = 0;
         for (String line : lines) {
@@ -75,7 +76,7 @@ public class Train {
                                 yval,
                                 outputNeurons));
             }
-            y.set(lineno, yval, 1.0);
+            y.set(yval, lineno, 1.0);
             for (int i = 1; i < fields.length; i++) {
                 String[] feature = fields[i].split(":");
                 int index = Integer.valueOf(feature[0]);
@@ -89,7 +90,7 @@ public class Train {
                                     index,
                                     inputNeurons));
                 }
-                x.set(lineno, index, value);
+                x.set(index, lineno, value);
             }
             lineno++;
         }

--- a/core/src/test/java/com/basistech/ninja/NetworkTest.java
+++ b/core/src/test/java/com/basistech/ninja/NetworkTest.java
@@ -312,8 +312,8 @@ public class NetworkTest {
         // 0 1 --> 1
         // 1 0 --> 1
         // 1 1 --> 0
-        SimpleMatrix x = new SimpleMatrix(4, 2, true, 0, 0, 0, 1, 1, 0, 1, 1);
-        SimpleMatrix y = new SimpleMatrix(4, 1, true, 1, 1, 1, 0);
+        SimpleMatrix x = new SimpleMatrix(2, 4, false, 0, 0, 0, 1, 1, 0, 1, 1);
+        SimpleMatrix y = new SimpleMatrix(1, 4, false, 1, 1, 1, 0);
 
         int maxEpochs = 100000;
         double learningRate = 0.01;


### PR DESCRIPTION
When we read examples as column vectors
we don't need to call transpose, which
can be expensive.

Things are a bit confusing since we only
work with SimpleMatrix. Ideally, we want
RowVector, ColVector, etc.